### PR TITLE
Configure locale to fix #14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,16 @@
 FROM debian:buster-slim
 
-RUN apt-get update && apt-get install gitit -y
+RUN apt-get update && apt-get install gitit locales locales-all -y
 
 COPY ./run-gitit.sh ./gitit.conf /work/
 
 RUN chmod +x /work/run-gitit.sh
 
 WORKDIR /work/
+
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
 
 CMD ["./run-gitit.sh"]

--- a/README.md
+++ b/README.md
@@ -5,3 +5,11 @@ Wikiの内容そのものに対するPull Request, Issueは受け付けており
 http://wiki.haskell.jp/ を直接編集するか、「disscuss」タブで議論して下さい。
 
 このWikiに限らず、Haskellに関して日本語で情報を共有したい場合や質問がある場合は[Haskell-jpのSlackチーム](https://haskell.jp/signin-slack.html)に投稿してください！
+
+## 管理者メモ
+
+デプロイしてログの確認をするときは
+
+```
+heroku container:push web -a $HEROKU_APP_NAME && heroku container:release web -a $HEROKU_APP_NAME && heroku logs --tail -a $HEROKU_APP_NAME
+```


### PR DESCRIPTION
コミットメッセージに書いたとおりですが、なぜか私のherokuアプリだと、 `Dockerfile` の **`ENV` に書いた環境変数が反映されない** という問題があるようなので、設定画面で `LC_ALL` などの環境変数を設定しておきました。
手元の環境だと普通に動いているので、不思議です。

思い起こすに、 https://devcenter.heroku.com/articles/container-registry-and-runtime#testing-an-image-locally 曰く

> We strongly recommend testing images locally as a non-root user, as containers are not run with root privileges in Heroku.

らしいから、ユーザーが違うとみてる環境変数も異なる、のかも知れません（どうユーザーを切り替えてるんだろう）。
まぁ、とりあえず動いているし、報告するのも面倒くさいのでこのまま様子見します。