### PR TITLE
ページのURLが変わってしまっていることを明記

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -27,7 +27,7 @@
   <h1 class="pageTitle"><a href="">ページが見つかりません</a></h1>
   
   <div id="wikipage">
-    <p>2022年11月20日、ホスティングサービスとして利用していたHerokuの無料プランの廃止が決まったことや、長期間編集される見込みがないことから、静的サイトとして<strong>読み込み専用</strong>で公開しています。現在は編集用のページや編集履歴にアクセスしても404 Not Foundが返ってきます。編集履歴を閲覧したい場合は<a href="https://github.com/haskell-jp/haskell-jp-wiki/commits/master">Gitリポジトリーにおける履歴</a>からご覧ください。編集したり新しいページを作成したりしたい場合は、<a href="https://scrapbox.io/haskell-shoen/">haskell-shoen</a>の利用をご検討ください。</p>
+    <p>2022年11月20日、ホスティングサービスとして利用していたHerokuの無料プランの廃止が決まったことや、長期間編集される見込みがないことから、静的サイトとして<strong>読み込み専用</strong>で公開しています。現在は編集用のページや編集履歴にアクセスしても404 Not Foundが返ってきます。そのほか、<strong>多くのページはURLが変わってしまっている</strong>点にご注意ください。編集履歴を閲覧したい場合は<a href="https://github.com/haskell-jp/haskell-jp-wiki/commits/master">Gitリポジトリーにおける履歴</a>からご覧ください。編集したり新しいページを作成したりしたい場合は、<a href="https://scrapbox.io/haskell-shoen/">haskell-shoen</a>の利用をご検討ください。</p>
 </div>
 </div>
             <div id="footer">powered by <a href="https://github.com/jgm/gitit/tree/master/">gitit</a> × <a href="https://haskellonheroku.com/">Haskell on Heroku</a></div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -428,7 +428,7 @@
 <h1 id="ようこそhaskell-jp-wikiへ">ようこそHaskell-jp wikiへ!</h1>
 <h2 id="このサイトについて">このサイトについて（現在は編集できない状態で公開しています！）</h2>
 <p>このWikiはHaskell関連情報を日本語でまとめるためのポータルサイトです。<br>
-  2022年11月まで<a href="http://gitit.net/">gitit</a>というWikiエンジン（もちろんHaskell製）で運用されておりましたが、ホスティングサービスとして利用していたHerokuの無料プランが廃止されたことや、長期間編集される見込みがないことから、現在は静的サイトとして<strong>読み込み専用</strong>で公開しています。編集用のページや編集履歴にアクセスしても404 Not Foundが返ってきます。編集履歴を閲覧したい場合は<a href="https://github.com/haskell-jp/haskell-jp-wiki/commits/master">Gitリポジトリーにおける履歴</a>からご覧ください。編集したい場合は今後は<a href="https://scrapbox.io/haskell-shoen/">haskell-shoen</a>の利用をご検討ください。</p>
+  2022年11月まで<a href="http://gitit.net/">gitit</a>というWikiエンジン（もちろんHaskell製）で運用されておりましたが、ホスティングサービスとして利用していたHerokuの無料プランが廃止されたことや、長期間編集される見込みがないことから、現在は静的サイトとして<strong>読み込み専用</strong>で公開しています。編集用のページや編集履歴にアクセスしても404 Not Foundが返ってきます。そのほか、<strong>多くのページはURLが変わってしまっている</strong>点にご注意ください。編集履歴を閲覧したい場合は<a href="https://github.com/haskell-jp/haskell-jp-wiki/commits/master">Gitリポジトリーにおける履歴</a>からご覧ください。編集したい場合は今後は<a href="https://scrapbox.io/haskell-shoen/">haskell-shoen</a>の利用をご検討ください。</p>
 <h2 id="コンテンツ">コンテンツ</h2>
 <ul>
 <li><a href="MailingList.html">メーリングリスト</a></li>


### PR DESCRIPTION
https://github.com/haskell-jp/haskell-jp-wiki/pull/18 の続きです。すみません、ドメインはそのままでもパスが変わるという重要な観点が抜けていました🙇 
引き続きそのままマージします。